### PR TITLE
Include Chef::DSL::Recipe in HWRPs which require it (and fix Chef12)

### DIFF
--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -24,6 +24,7 @@ class Chef
     # The provider for lvm_logical_volume resource
     #
     class LvmLogicalVolume < Chef::Provider
+      include Chef::DSL::Recipe
       include Chef::Mixin::ShellOut
 
       # Loads the current resource attributes

--- a/libraries/provider_lvm_volume_group.rb
+++ b/libraries/provider_lvm_volume_group.rb
@@ -24,6 +24,7 @@ class Chef
     # The provider for lvm_volume_group resource
     #
     class LvmVolumeGroup < Chef::Provider
+      include Chef::DSL::Recipe
       include Chef::Mixin::ShellOut
 
       # Loads the current resource attributes


### PR DESCRIPTION
Upgrading to Chef12 has left our LVM HWRP's unusable. It seems that the problem is that Chef12 no longer includes the Recipe DSL for heavyweight providers. I've simply added the include where required. Tested successfully on Chef12, but not Chef11... I suspect it should be fine though.

We will be switching to a fork containing this change in the meantime as this hampers our ability to bootstrap new hosts. On another note, if this (or other related) fix is held up for one reason or another, we should update the Readme to reflect Chef12 incompatibility.

Directly related to/alternate approach for:
https://github.com/opscode-cookbooks/lvm/issues/44
https://github.com/opscode-cookbooks/lvm/issues/42
https://github.com/opscode-cookbooks/lvm/pull/41