### PR TITLE
[CHEF-4436] - gem package version option

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,4 +21,5 @@ package 'lvm2'
 
 chef_gem 'di-ruby-lvm' do
   action :install
+  version '> 0.0'
 end


### PR DESCRIPTION
To address CHEF-4436.  Simply added a generic version string to the chef_gem block.

I'm not positive, but this may also address PR #49 - when I ran this, it installed the latest version of both di-ruby-lvm & di-ruby-lvm-attrib, and it did not force an upgrade when I had an earlier version installed.

This, of course, assumes that there is no technical dependency for a minimum version of di-ruby-lvm.