### PR TITLE
Make the metadata compatible with chef 11.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,5 +13,5 @@ supports 'ubuntu'
 
 recipe 'lvm', 'Installs lvm2 package'
 
-source_url 'https://github.com/opscode-cookbooks/lvm'
-issues_url 'https://github.com/opscode-cookbooks/lvm/issues'
+source_url 'https://github.com/opscode-cookbooks/lvm' if respond_to?(:source_url)
+issues_url 'https://github.com/opscode-cookbooks/lvm/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Chef 12 methods used in the metadata are incompatible with chef 11.  Checked for response.