### PR TITLE
Bump version of di-ruby-lvm-attrib

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
 default['lvm']['di-ruby-lvm']['version'] = '0.1.3'
-default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.16'
+default['lvm']['di-ruby-lvm-attrib']['version'] = '0.0.21'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -10,7 +10,7 @@ describe 'lvm::default' do
   end
 
   it 'installs `di-ruby-lvm-attrib` as a Ruby gem' do
-    expect(chef_run).to install_chef_gem('di-ruby-lvm-attrib').with(:version => '0.0.16')
+    expect(chef_run).to install_chef_gem('di-ruby-lvm-attrib').with(:version => '0.0.21')
   end
 
   it 'installs `di-ruby-lvm` as a Ruby gem' do


### PR DESCRIPTION
To include support of more versions of LVM added in more recent versions of `di-ruby-lvm-attrib`.